### PR TITLE
bug: 버그 수정

### DIFF
--- a/src/controller/gridCoordinatesController.js
+++ b/src/controller/gridCoordinatesController.js
@@ -11,8 +11,8 @@ const getGridCoordinates = async (req, res) => {
 
 const getGridCoordinatesByGrid = async (req, res) => {
   try {
-    const { nx, ny } = req.params;
-    const gridCoordinates = await GridCoordinatesService.getGridCoordinatesByGrid(nx, ny);
+    const { gridX, gridY } = req.params;
+    const gridCoordinates = await GridCoordinatesService.getGridCoordinatesByGrid(gridX, gridY);
     res.json(gridCoordinates);
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/src/controller/vilageFcstController.js
+++ b/src/controller/vilageFcstController.js
@@ -2,8 +2,8 @@ import vilageFcstService from "../service/vilageFcstService.js";
 
 const getVilageFcstByGrid = async (req, res) => {
   try {
-    const { nx, ny } = req.params;
-    const vilageFcst = await vilageFcstService.getVilageFcstByGrid(nx, ny);
+    const { gridX, gridY } = req.params;
+    const vilageFcst = await vilageFcstService.getVilageFcstByGrid(gridX, gridY);
     res.json(vilageFcst);
   } catch (error) {
     res.status(500).json({ error: error.message });

--- a/src/model/vilageFcst.js
+++ b/src/model/vilageFcst.js
@@ -11,8 +11,8 @@ import sequelize from "../config/database.js";
  * @property {Date} fest_date
  * @property {string} fest_time
  * @property {number} fcst_value
- * @property {number} nx
- * @property {number} ny
+ * @property {number} grid_x
+ * @property {number} grid_y
  * @property {Date} created_at
  */
 const VilageFcst = sequelize.define(
@@ -48,11 +48,11 @@ const VilageFcst = sequelize.define(
       type: DataTypes.DECIMAL,
       allowNull: false,
     },
-    nx: {
+    grid_x: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },
-    ny: {
+    grid_y: {
       type: DataTypes.INTEGER,
       allowNull: false,
     },

--- a/src/repository/gridCoordinatesRepository.js
+++ b/src/repository/gridCoordinatesRepository.js
@@ -5,11 +5,11 @@ class GridCoordinatesRepository {
     return GridCoordinates.findAll();
   }
   
-  async findByGrid(nx, ny) {
+  async findByGrid(gridX, gridY) {
     return GridCoordinates.findOne({
       where: {
-        nx: nx,
-        ny: ny,
+        grid_x: gridX,
+        grid_y: gridY,
       },
     });
   }

--- a/src/repository/vilageFcstRepository.js
+++ b/src/repository/vilageFcstRepository.js
@@ -1,11 +1,11 @@
 import VilageFcst from "../model/vilageFcst.js";
 
 class VilageFcstRepository {
-  async findByGrid(nx, ny) {
+  async findByGrid(gridX, gridY) {
     return VilageFcst.findAll({
       where: {
-        nx: nx,
-        ny: ny,
+        grid_x: gridX,
+        grid_y: gridY,
       },
     });
   }

--- a/src/route/gridCoordinatesRoute.js
+++ b/src/route/gridCoordinatesRoute.js
@@ -4,6 +4,6 @@ import { getGridCoordinates, getGridCoordinatesByGrid } from "../controller/grid
 const GridCoordinatesRoute = Router();
 
 GridCoordinatesRoute.get("/", getGridCoordinates);
-GridCoordinatesRoute.get("/:nx/:ny", getGridCoordinatesByGrid);
+GridCoordinatesRoute.get("/:gridX/:gridY", getGridCoordinatesByGrid);
 
 export default GridCoordinatesRoute;

--- a/src/route/vilageFcstRoute.js
+++ b/src/route/vilageFcstRoute.js
@@ -3,6 +3,6 @@ import { getVilageFcstByGrid } from "../controller/vilageFcstController.js";
 
 const VilageFcstRoute = Router();
 
-VilageFcstRoute.get("/:nx/:ny", getVilageFcstByGrid);
+VilageFcstRoute.get("/:gridX/:gridY", getVilageFcstByGrid);
 
 export default VilageFcstRoute;

--- a/src/service/gridCoordinatesService.js
+++ b/src/service/gridCoordinatesService.js
@@ -5,11 +5,11 @@ class GridCoordinatesRepositoryService {
     return GridCoordinatesRepository.findAll();
   }
 
-  async getGridCoordinatesByGrid(nx, ny) {
-    if (nx === undefined || ny === undefined || nx === null || ny === null) {
-      throw new Error("nx와 ny가 필요합니다.");
+  async getGridCoordinatesByGrid(gridX, gridY) {
+    if (gridX === undefined || gridY === undefined || gridX === null || gridY === null) {
+      throw new Error("gridX와 gridY가 필요합니다.");
     }
-    return GridCoordinatesRepository.findByGrid(nx, ny);
+    return GridCoordinatesRepository.findByGrid(gridX, gridY);
   }
 }
 

--- a/src/service/vilageFcstService.js
+++ b/src/service/vilageFcstService.js
@@ -1,11 +1,11 @@
 import VilageFcstRepository from "../repository/vilageFcstRepository.js";
 
 class VilageFcstRepositoryService {
-  async getVilageFcstByGrid(nx, ny) {
-    if (nx === undefined || ny === undefined || nx === null || ny === null) {
-      throw new Error("nx와 ny가 필요합니다.");
+  async getVilageFcstByGrid(gridX, gridY) {
+    if (gridX === undefined || gridY === undefined || gridX === null || gridY === null) {
+      throw new Error("gridX와 gridY가 필요합니다.");
     }
-    return VilageFcstRepository.findByGrid(nx, ny);
+    return VilageFcstRepository.findByGrid(gridX, gridY);
   }
 }
 


### PR DESCRIPTION
## Sourcery 요약

버그 수정:
- 애플리케이션 전반에서 그리드 좌표 파라미터의 일관성 없는 명명법을 수정합니다. 'nx' 및 'ny'를 'gridX' 및 'gridY'로 이름을 변경하여 일관성을 유지합니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Corrects inconsistent naming of grid coordinate parameters across the application by renaming 'nx' and 'ny' to 'gridX' and 'gridY' to ensure consistency.

</details>